### PR TITLE
Initial API proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,109 @@
 An experimental client library for InfluxDB. This client library is
 designed to make working with InfluxDB easier and support the full
 breadth of features within InfluxDB at the same time.
+
+## Example
+
+```go
+client := influxdb.Client{}
+
+influxdb.Discard(client.Query("CREATE DATABASE mydb", nil))
+defer influxdb.Discard(client.Query("DROP DATABASE mydb", nil))
+
+now := time.Now().Truncate(time.Second).Add(-99*time.Second)
+pts := make([]influxdb.Point, 0, 100)
+for i := 0; i < 100; i++ {
+	pts = append(pts, influxdb.NewPoint("cpu", influxdb.Value(i), now.Add(i*time.Second)))
+}
+client.Write(pts...)
+
+reader, _, err := client.Query("SELECT mean(value) FROM cpu")
+if err != nil {
+	log.Fatal(err)
+}
+defer reader.Close()
+
+result := influxdb.Result{}
+for {
+	if err := reader.Read(&result); err != nil {
+		log.Fatal(err)
+  }
+
+	s := result.Series[0]
+	fmt.Printf("name: %v\n", s.Name)
+	for _, values := range s.Values {
+		for i, column := range s.Columns {
+			fmt.Printf("%v: %v\n", column, values[i])
+		}
+	}
+}
+```
+
+## Writing Data
+
+Writing data to a database is very simple.
+
+```go
+client := influxdb.Client{}
+pt := influxdb.NewPoint("cpu", influxdb.Value(2.0), time.Time{})
+client.Write(pt)
+```
+
+This will write the following line over the line protocol:
+
+```
+cpu value=2.0
+```
+
+### Using custom fields
+
+The most common field key is `value` and the
+`influxdb.Value(interface{})` function exists for this common use case.
+If you need to write more than one field, you can create a map of
+fields very easily.
+
+```go
+client := influxdb.Client{}
+
+fields := influxdb.Fields{
+	"value": 2.0,
+	"total": 10.0,
+}
+pt := influxdb.NewPoint("cpu", fields, time.Time{})
+
+client.Write(pt)
+```
+
+Any of the following types can be used as a field value. The real type
+is in bold and any of the other supported types will be cast to the
+bolded type by the client.
+
+* float32, **float64**
+* int, int32, **int64**
+* **string**
+* **bool**
+
+Unsigned integers aren't supported by InfluxDB and they are not
+automatically cast so that precision isn't lost.
+
+### Writing a point with tags
+
+A point can be written with tags very easily by passing in a list of
+tags.
+
+```go
+client := influxdb.Client{}
+
+tags := []influxdb.Tag{
+	{Key: "host", Value: "server01"},
+  {Key: "region", Value: "useast"},
+}
+pt := influxdb.NewPointWithTags("cpu", tags, influxdb.Value(2.0), time.Time{})
+
+client.Write(pt)
+```
+
+When writing, the tags should be sorted for best write performance. The
+API uses a slice instead of a map for keeping tags so the writer does
+not have to create a slice and sort the tags itself everytime you write.
+For best performance, try to reuse tags for multiple calls.

--- a/buffered_writer.go
+++ b/buffered_writer.go
@@ -1,0 +1,63 @@
+package influxdb
+
+import "time"
+
+// BufferOptions contains options for configuring how often the BufferedWriter
+// will flush metrics and how large the buffer will be.
+type BufferOptions struct {
+	// BufferSize is the maximum buffer size before points will be
+	// automatically flushed.
+	BufferSize int
+
+	// FlushInterval is the time interval to perform a Flush operation. A flush
+	// that fails when this interval is reached will call OnFlushError.
+	FlushInterval time.Duration
+
+	// RetryLimit is the number of maximum number of retries before it is
+	// considered a failure. If the Writer returns a WriteError, no retry will
+	// be attempted since the failure was with the data and not the connection.
+	RetryLimit int
+
+	// OnFlushError will be called if a batch of points fails to write to the
+	// underlying Writer during an automatic flush. This function will not be
+	// called if the Flush was manually performed.
+	// If this is unset, the points will be dropped and no error message will
+	// be printed. This will only be called if the RetryLimit is exceeded. Do
+	// not try to rewrite the points in this function as a way of retrying a
+	// failed write.
+	OnFlushError func(points []Point, err error)
+}
+
+// BufferedWriter buffers points and writes them to the underlying Writer
+// either after the buffer has been filled or the FlushInterval has been
+// reached.
+type BufferedWriter struct {
+	w   Writer
+	opt BufferOptions
+}
+
+// NewBufferedWriter creates a new BufferedWriter.
+func NewBufferedWriter(w Writer, opt *BufferOptions) *BufferedWriter {
+	return nil
+}
+
+// Write writes the points to buffer. If the buffer exceeds the BufferSize, the
+// buffer will be flushed. This method does not return an error from a failed
+// flush and will not wait for the flush to complete. Use OnFlushError to act
+// on any errors from automatic flushes.
+func (b *BufferedWriter) Write(points ...Point) error {
+	return nil
+}
+
+// Close closes the BufferedWriter. It will Flush any remaining data. Any
+// errors from Flush will be returned here.
+func (b *BufferedWriter) Close() error {
+	return nil
+}
+
+// Flush will force the current buffer to flush and write any buffered metrics
+// to the Writer. If there was some error while writing, that error will be
+// returned here and OnFlushError will not be called.
+func (b *BufferedWriter) Flush() error {
+	return nil
+}

--- a/buffered_writer_test.go
+++ b/buffered_writer_test.go
@@ -1,0 +1,1 @@
+package influxdb_test

--- a/client.go
+++ b/client.go
@@ -120,8 +120,8 @@ type QueryMeta struct {
 // application/x-www-form-urlencoded. If the query is an io.Reader, the query is sent
 // as a file using multipart/form-data. The first is more useful for a single ad-hoc
 // query, but the second can be better for running large multi-command queries.
-func (c *Client) NewQuery(q interface{}, opt *QueryOptions) (*http.Request, error) {
-	return &http.Request{URL: &url.URL{}}, nil
+func (c *Client) NewQuery(method string, q interface{}, opt *QueryOptions) (*http.Request, error) {
+	return &http.Request{Method: method, URL: &url.URL{}}, nil
 }
 
 // Select executes a query and parses the results from the stream.

--- a/client.go
+++ b/client.go
@@ -1,0 +1,141 @@
+package influxdb
+
+import (
+	"io"
+	"net/http"
+)
+
+// Precision is the requested precision.
+type Precision string
+
+const (
+	// PrecisionNanosecond represents nanosecond precision.
+	PrecisionNanosecond = Precision("n")
+
+	// PrecisionMicrosecond represents microsecond precision.
+	PrecisionMicrosecond = Precision("u")
+
+	// PrecisionMillisecond represents millisecond precision.
+	PrecisionMillisecond = Precision("ms")
+
+	// PrecisionSecond represents second precision.
+	PrecisionSecond = Precision("s")
+
+	// PrecisionMinute represents minute precision.
+	PrecisionMinute = Precision("m")
+
+	// PrecisionHour represents hour precision.
+	PrecisionHour = Precision("h")
+)
+
+func (p Precision) String() string {
+	return string(p)
+}
+
+// Consistency is the requested consistency of the write.
+type Consistency string
+
+const (
+	// ConsistencyAll requires all data nodes to acknowledge a write.
+	ConsistencyAll = Consistency("all")
+
+	// ConsistencyOne requires at least one data node acknowledge a write.
+	ConsistencyOne = Consistency("one")
+
+	// ConsistencyQuorum requires a quorum of data nodes to acknowledge a write.
+	ConsistencyQuorum = Consistency("quorum")
+
+	// ConsistencyAny allows for hinted hand off, potentially no write happened yet.
+	ConsistencyAny = Consistency("any")
+)
+
+func (c Consistency) String() string {
+	return string(c)
+}
+
+// Client is a client that communicates with an InfluxDB server.
+type Client struct {
+	// HTTP client used to talk to the InfluxDB HTTP server.
+	*http.Client
+
+	// Proto is the protocol to use when issuing client requests. If this is left
+	// blank, it defaults to http.
+	Proto string
+
+	// Addr is the address to use when issuing client requests. If this is left
+	// blank, it defaults to localhost:8086.
+	Addr string
+
+	// Path is the default HTTP path to prefix to all requests.
+	Path string
+
+	// Database is the default database to use when writing or querying.
+	Database string
+
+	// RetentionPolicy is the default database to use when writing or querying.
+	RetentionPolicy string
+}
+
+// NewClient creates a new client pointed to the parsed hostname.
+func NewClient(url string) (*Client, error) {
+	proto, addr, path, err := ParseUrl(url)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		Proto: proto,
+		Addr:  addr,
+		Path:  path,
+	}, nil
+}
+
+// ParseUrl parses a url and retrieves the protocol, address, and base path (if relevant).
+func ParseUrl(rawurl string) (proto, addr, path string, err error) {
+	return "http", "localhost:8086", "", nil
+}
+
+// QueryOptions is a set of configuration options for configuring queries.
+type QueryOptions struct {
+	Database        string
+	RetentionPolicy string
+	Chunked         bool
+	ChunkSize       int
+	Pretty          bool
+	Format          string
+	Async           bool
+}
+
+// QueryMeta has meta information about the query returned by the server.
+type QueryMeta struct {
+	Format string
+}
+
+// Query executes a query and parses the results from the stream.
+func (c *Client) Query(q string, opt *QueryOptions) (Reader, QueryMeta, error) {
+	r, meta, err := c.RawQuery(q, opt)
+	if err != nil {
+		return nil, meta, err
+	}
+
+	reader, err := NewReader(r, meta)
+	return reader, meta, err
+}
+
+// RawQuery executes a query and returns the raw stream.
+func (c *Client) RawQuery(q string, opt *QueryOptions) (io.ReadCloser, QueryMeta, error) {
+	return nil, QueryMeta{}, nil
+}
+
+// WriteOptions is a set of configuration options for writes.
+type WriteOptions struct {
+	Database        string
+	RetentionPolicy string
+	Precision       Precision
+	Consistency     Consistency
+}
+
+// Write writes a batch of points over the line protocol to the HTTP /write endpoint.
+func (c *Client) Write(points []Point, opt *WriteOptions) error {
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -127,6 +127,24 @@ func (c *Client) RawQuery(q string, opt *QueryOptions) (io.ReadCloser, QueryMeta
 	return nil, QueryMeta{}, nil
 }
 
+// Discard discards the output from a query and passes any errors encountered.
+// This will swallow the io.EOF error from the Reader.
+func Discard(r Reader, meta QueryMeta, err error) error {
+	if err != nil {
+		return err
+	}
+
+	defer r.Close()
+	for {
+		if err := r.Read(nil); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
 // WriteOptions is a set of configuration options for writes.
 type WriteOptions struct {
 	Database        string

--- a/client_test.go
+++ b/client_test.go
@@ -196,7 +196,7 @@ func TestClient_NewQuery(t *testing.T) {
 		Pretty:          true,
 		Format:          "json",
 	}
-	req, err := client.NewQuery("SELECT * FROM cpu", &opt)
+	req, err := client.NewQuery("POST", "SELECT * FROM cpu", &opt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +385,7 @@ func TestClient_NewWrite(t *testing.T) {
 	buf := bytes.NewBufferString("expected body")
 
 	client := influxdb.Client{}
-	opt := WriteOptions{
+	opt := influxdb.WriteOptions{
 		Database:        "db0",
 		RetentionPolicy: "rp0",
 		Precision:       influxdb.PrecisionSecond,

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,398 @@
+package influxdb_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	influxdb "github.com/influxdata/influxdb-client"
+)
+
+func TestPrecision_String(t *testing.T) {
+	tests := []struct {
+		precision influxdb.Precision
+		want      string
+	}{
+		{
+			precision: influxdb.PrecisionNanosecond,
+			want:      "n",
+		},
+		{
+			precision: influxdb.PrecisionMicrosecond,
+			want:      "u",
+		},
+		{
+			precision: influxdb.PrecisionMillisecond,
+			want:      "ms",
+		},
+		{
+			precision: influxdb.PrecisionSecond,
+			want:      "s",
+		},
+		{
+			precision: influxdb.PrecisionMinute,
+			want:      "m",
+		},
+		{
+			precision: influxdb.PrecisionHour,
+			want:      "h",
+		},
+	}
+
+	for i, tt := range tests {
+		if have := tt.precision.String(); have != tt.want {
+			t.Errorf("%d. String() = %q; want %q", i, have, tt.want)
+		}
+	}
+}
+
+func TestConsistency_String(t *testing.T) {
+	tests := []struct {
+		consistency influxdb.Consistency
+		want        string
+	}{
+		{
+			consistency: influxdb.ConsistencyAll,
+			want:        "all",
+		},
+		{
+			consistency: influxdb.ConsistencyOne,
+			want:        "one",
+		},
+		{
+			consistency: influxdb.ConsistencyQuorum,
+			want:        "quorum",
+		},
+		{
+			consistency: influxdb.ConsistencyAny,
+			want:        "any",
+		},
+	}
+
+	for i, tt := range tests {
+		if have := tt.consistency.String(); have != tt.want {
+			t.Errorf("%d. String() = %q; want %q", i, have, tt.want)
+		}
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	c, err := influxdb.NewClient("http://localhost:8086")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.Proto != "http" {
+		t.Errorf("c.Proto = %q; want %q", c.Proto, "http")
+	}
+	if c.Addr != "localhost:8086" {
+		t.Errorf("c.Addr = %q; want %q", c.Addr, "localhost:8086")
+	}
+	if c.Path != "" {
+		t.Errorf("c.Path = %q; want %q", c.Path, "")
+	}
+
+	_, err = influxdb.NewClient("invalid url")
+	if err == nil {
+		t.Errorf("expected error while parsing url")
+	}
+}
+
+func TestClient_Do(t *testing.T) {
+	done := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/want"; got != want {
+			t.Errorf("got %q; want %q", got, want)
+		}
+		w.WriteHeader(http.StatusNoContent)
+		close(done)
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest("GET", server.URL+"/want", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := influxdb.NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("StatusCode = %q; want %q", resp.StatusCode, http.StatusNoContent)
+	}
+
+	select {
+	case <-done:
+	default:
+		t.Errorf("handler was not triggered")
+	}
+}
+
+func TestClient_Ping_Success(t *testing.T) {
+	done := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, "GET"; got != want {
+			t.Errorf("Method = %q; want %q", got, want)
+		}
+		if got, want := r.URL.Path, "/ping"; got != want {
+			t.Errorf("Path = %q; want %q", got, want)
+		}
+		w.WriteHeader(http.StatusNoContent)
+		close(done)
+	}))
+	defer server.Close()
+
+	client, err := influxdb.NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.Ping(); err != nil {
+		t.Error(err)
+	}
+
+	select {
+	case <-done:
+	default:
+		t.Errorf("handler was not triggered")
+	}
+}
+
+func TestClient_Ping_Failure(t *testing.T) {
+	server := httptest.NewServer(nil)
+	url := server.URL
+	server.Close()
+
+	client, err := influxdb.NewClient(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.Ping(); err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestClient_NewQuery(t *testing.T) {
+	client := influxdb.Client{}
+	opt := influxdb.QueryOptions{
+		Database:        "db0",
+		RetentionPolicy: "rp0",
+		Chunked:         true,
+		ChunkSize:       1024,
+		Pretty:          true,
+		Format:          "json",
+	}
+	req, err := client.NewQuery("SELECT * FROM cpu", &opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if req.Method != "POST" {
+		t.Errorf("Method = %q; want %q", req.Method, "POST")
+	}
+
+	// Query options are put into the URL so they show up in the server log to aid with debugging.
+	values := req.URL.Query()
+	if got, want := values.Get("db"), "db0"; got != want {
+		t.Errorf("db = %q; want %q", got, want)
+	}
+	if got, want := values.Get("rp"), "rp0"; got != want {
+		t.Errorf("rp = %q; want %q", got, want)
+	}
+	if got, want := values.Get("chunked"), "true"; got != want {
+		t.Errorf("chunked = %q; want %q", got, want)
+	}
+	if got, want := values.Get("chunk_size"), "1024"; got != want {
+		t.Errorf("chunk_size = %q; want %q", got, want)
+	}
+	if got, want := values.Get("pretty"), "true"; got != want {
+		t.Errorf("pretty = %q; want %q", got, want)
+	}
+
+	if got, want := req.Header.Get("Content-Type"), "application/x-www-form-urlencoded"; got != want {
+		t.Errorf("Content-Type = %q; want %q", got, want)
+	}
+
+	if req.Body == nil {
+		t.Fatal("expected request to have a body")
+	}
+
+	out, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := url.ParseQuery(string(out))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The query itself is put into the body so it can be an arbitary length
+	// without any limitations on GET.
+	if got, want := body.Get("q"), "SELECT * FROM cpu"; got != want {
+		t.Errorf("q = %q; want %q", got, want)
+	}
+}
+
+func TestClient_Select(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, "GET"; got != want {
+			t.Errorf("Method = %q; want %q", got, want)
+		}
+
+		values := r.URL.Query()
+		if got, want := values.Get("db"), "db0"; got != want {
+			t.Errorf("db = %q; want %q", got, want)
+		}
+		if got, want := values.Get("rp"), ""; got != want {
+			t.Errorf("rp = %q; want %q", got, want)
+		}
+		if got, want := values.Get("q"), "SELECT mean(value) FROM cpu"; got != want {
+			t.Errorf("q = %q; want %q", got, want)
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"results":[{"name":"cpu","columns":["time","mean"],"values":[["1970-01-01T00:00:00Z",5]]}]}`)
+		w.Write([]byte("\n"))
+	}))
+	defer server.Close()
+
+	client, err := influxdb.NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opt := influxdb.QueryOptions{Database: "db0"}
+	r, err := client.Select("SELECT mean(value) FROM cpu", &opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	result := influxdb.Result{}
+	if err := r.Read(&result); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Series) != 1 {
+		t.Fatalf("number of series = %q; want %q", len(result.Series), 1)
+	}
+
+	series := result.Series[0]
+	if series.Name != "cpu" {
+		t.Errorf("Name = %q; want %q", series.Name, "cpu")
+	}
+	if got, want := series.Columns, []string{"time", "mean"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Columns = %q; want %q", got, want)
+	}
+	if len(series.Values) != 1 {
+		t.Errorf("number of values = %q; want %q", len(series.Values), 1)
+	} else {
+		values := series.Values[0]
+		if len(values) != 2 {
+			t.Errorf("length of values slice = %q; want %q", len(values), 2)
+		} else {
+			if got, want := values[0].(string), "1970-01-01T00:00:00Z"; got != want {
+				t.Errorf("time value = %q; want %q", got, want)
+			}
+			if got, want := values[1].(float64), 5.0; got != want {
+				t.Errorf("mean value = %q; want %q", got, want)
+			}
+		}
+	}
+
+	if err := r.Read(&result); err != io.EOF {
+		t.Errorf("got error %q; want %q", err, io.EOF)
+	}
+}
+
+func TestClient_Execute_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, "GET"; got != want {
+			t.Errorf("Method = %q; want %q", got, want)
+		}
+
+		values := r.URL.Query()
+		if got, want := values.Get("q"), "CREATE DATABASE db0"; got != want {
+			t.Errorf("q = %q; want %q", got, want)
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"results":[{}]}`)
+		w.Write([]byte("\n"))
+	}))
+	defer server.Close()
+
+	client, err := influxdb.NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.Execute("CREATE DATABASE db0", nil); err != nil {
+		t.Errorf("got error %q; want nil", err)
+	}
+}
+
+func TestClient_Execute_Failure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, "GET"; got != want {
+			t.Errorf("Method = %q; want %q", got, want)
+		}
+
+		values := r.URL.Query()
+		if got, want := values.Get("q"), "CREATE DATABASE db0"; got != want {
+			t.Errorf("q = %q; want %q", got, want)
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"results":[{"error":"expected err"}]}`)
+		w.Write([]byte("\n"))
+	}))
+	defer server.Close()
+
+	client, err := influxdb.NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.Execute("CREATE DATABASE db0", nil); err == nil {
+		t.Errorf("expected error")
+	} else if e, ok := err.(*influxdb.ResultError); !ok {
+		t.Errorf("got error type %T; want %T", err, e)
+	} else if e.Err != "expected err" {
+		t.Errorf("error message %q; want %q", e.Err, "expected err")
+	}
+}
+
+func TestClient_NewWrite(t *testing.T) {
+	buf := bytes.NewBufferString("expected body")
+
+	client := influxdb.Client{}
+	opt := WriteOptions{
+		Database:        "db0",
+		RetentionPolicy: "rp0",
+		Precision:       influxdb.PrecisionSecond,
+		Consistency:     influxdb.ConsistencyOne,
+	}
+	req, err := client.NewWrite(buf, &opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/http_writer.go
+++ b/http_writer.go
@@ -1,0 +1,16 @@
+package influxdb
+
+// HTTPWriter writes points in line protocol to the HTTP /write endpoint.
+type HTTPWriter struct {
+	client *Client
+	opt    *WriteOptions
+}
+
+// NewHTTPWriter creates a new HTTPWriter.
+func NewHTTPWriter(client *Client, opt *WriteOptions) Writer {
+	return nil
+}
+
+func (w *HTTPWriter) Write(points ...Point) error {
+	return w.client.Write(points, w.opt)
+}

--- a/http_writer_test.go
+++ b/http_writer_test.go
@@ -1,0 +1,6 @@
+package influxdb
+
+import "testing"
+
+func TestHTTPWriter(t *testing.T) {
+}

--- a/point.go
+++ b/point.go
@@ -1,0 +1,51 @@
+package influxdb
+
+import "time"
+
+// Tag is a key/value pair of strings that is indexed when inserted into a measurement.
+type Tag struct {
+	Key   string
+	Value string
+}
+
+// Tags is a list of Tag structs. For optimal efficiency, this should be inserted
+// into InfluxDB in a sorted order and should only contain unique values.
+type Tags []Tag
+
+func (a Tags) Less(i, j int) bool { return a[i].Key < a[j].Key }
+func (a Tags) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a Tags) Len() int           { return len(a) }
+
+// Fields is a mapping of keys to field values. The values must be a float64,
+// int64, string, or bool.
+type Fields map[string]interface{}
+
+// Value returns a new Fields map with the value key set to the passed in
+// interface. This is a convenience function for the common use case of
+// inserting a single field with a field key of "value".
+func Value(v interface{}) Fields {
+	return Fields{"value": v}
+}
+
+// Point is a point that can be inserted into a measurement at a time.
+type Point struct {
+	Name   string
+	Tags   Tags
+	Fields Fields
+	Time   int64
+}
+
+// NewPoint creates a new point with the given name and fields.
+func NewPoint(name string, fields Fields, timestamp time.Time) Point {
+	return NewPointWithTags(name, nil, fields, timestamp)
+}
+
+// NewPointWithTags creates a new point with the given name, tags, and fields.
+func NewPointWithTags(name string, tags Tags, fields Fields, timestamp time.Time) Point {
+	return Point{
+		Name:   name,
+		Tags:   tags,
+		Fields: fields,
+		Time:   timestamp.UnixNano(),
+	}
+}

--- a/point.go
+++ b/point.go
@@ -1,6 +1,14 @@
 package influxdb
 
-import "time"
+import (
+	"io"
+	"math"
+	"time"
+)
+
+// DefaultWriteProtocol is the default write protocol for points to be written in.
+// This will always match the write protocol expected by a request created with NewWrite.
+const DefaultWriteProtocol = 1
 
 // Tag is a key/value pair of strings that is indexed when inserted into a measurement.
 type Tag struct {
@@ -42,10 +50,45 @@ func NewPoint(name string, fields Fields, timestamp time.Time) Point {
 
 // NewPointWithTags creates a new point with the given name, tags, and fields.
 func NewPointWithTags(name string, tags Tags, fields Fields, timestamp time.Time) Point {
-	return Point{
+	pt := Point{
 		Name:   name,
 		Tags:   tags,
 		Fields: fields,
-		Time:   timestamp.UnixNano(),
 	}
+	pt.SetTime(timestamp)
+	return pt
+}
+
+// HasTimeSet checks if the time is set on this point.
+func (p *Point) HasTimeSet() bool {
+	return p.Time != int64(math.MinInt64)
+}
+
+// SetTime sets the time on this point. An empty time value will unset the time
+// and cause the point to be written without any time (using the current time on the server).
+func (p *Point) SetTime(timestamp time.Time) {
+	if !timestamp.IsZero() {
+		p.Time = timestamp.UnixNano()
+	} else {
+		// The value of math.MinInt64 is not supported by InfluxDB and is used to signal
+		// there is no time set.
+		p.Time = int64(math.MinInt64)
+	}
+}
+
+// Write writes the point to the writer in the specified protocol. If the
+// protocol is set to 0, the DefaultWriteProtocol is used. The
+// DefaultWriteProtocol will always match the default request created by
+// NewWrite.
+//
+// There is currently only one protocol version and it is version 1. If you
+// manually create the request and use this method to write to a request, be
+// sure to set this to the write protocol version you want to use. If you are
+// using this library and just want more control over writing to the request
+// object created by this library, you can just use zero.
+func (p *Point) Write(w io.Writer, protocol int) error {
+	if protocol == 0 {
+		protocol = DefaultWriteProtocol
+	}
+	return nil
 }

--- a/point_test.go
+++ b/point_test.go
@@ -1,0 +1,105 @@
+package influxdb_test
+
+import (
+	"math"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	influxdb "github.com/influxdata/influxdb-client"
+)
+
+func TestTags_Sort(t *testing.T) {
+	tags := []influxdb.Tag{
+		{Key: "region", Value: "useast"},
+		{Key: "host", Value: "server01"},
+	}
+	sort.Sort(influxdb.Tags(tags))
+
+	if tags[0].Key != "host" {
+		t.Errorf("have %q, want %q", tags[0].Key, "host")
+	}
+	if tags[0].Value != "server01" {
+		t.Errorf("have %q, want %q", tags[0].Value, "server01")
+	}
+	if tags[1].Key != "region" {
+		t.Errorf("have %q, want %q", tags[0].Key, "region")
+	}
+	if tags[1].Value != "useast" {
+		t.Errorf("have %q, want %q", tags[0].Value, "useast")
+	}
+}
+
+func TestValue(t *testing.T) {
+	fields := influxdb.Value(2.0)
+	if want := influxdb.Fields(map[string]interface{}{"value": 2.0}); !reflect.DeepEqual(fields, want) {
+		t.Errorf("have %q, want %q", fields, want)
+	}
+}
+
+func TestNewPoint(t *testing.T) {
+	now := time.Now()
+	pt := influxdb.NewPoint("cpu", influxdb.Value(2.0), now)
+	if pt.Name != "cpu" {
+		t.Errorf("pt.Name = %q; want %q", pt.Name, "cpu")
+	}
+	if want := influxdb.Tags(nil); !reflect.DeepEqual(pt.Tags, want) {
+		t.Errorf("pt.Tags = %q; want %q", pt.Tags, want)
+	}
+	if want := influxdb.Fields(map[string]interface{}{"value": 2.0}); !reflect.DeepEqual(pt.Fields, want) {
+		t.Errorf("pt.Fields = %q; want %q", pt.Fields, want)
+	}
+	if pt.Time != now.UnixNano() {
+		t.Errorf("pt.Time = %q; want %q", pt.Time, now.UnixNano())
+	}
+}
+
+func TestNewPointWithTags(t *testing.T) {
+	now := time.Now()
+	pt := influxdb.NewPointWithTags("cpu",
+		[]influxdb.Tag{{Key: "host", Value: "server01"}},
+		influxdb.Value(2.0), now)
+	if pt.Name != "cpu" {
+		t.Errorf("pt.Name = %q; want %q", pt.Name, "cpu")
+	}
+	if want := influxdb.Tags([]influxdb.Tag{{Key: "host", Value: "server01"}}); !reflect.DeepEqual(pt.Tags, want) {
+		t.Errorf("pt.Tags = %q; want %q", pt.Tags, want)
+	}
+	if want := influxdb.Fields(map[string]interface{}{"value": 2.0}); !reflect.DeepEqual(pt.Fields, want) {
+		t.Errorf("pt.Fields = %q; want %q", pt.Fields, want)
+	}
+	if pt.Time != now.UnixNano() {
+		t.Errorf("pt.Time = %q; want %q", pt.Time, now.UnixNano())
+	}
+}
+
+func TestPoint_HasTimeSet(t *testing.T) {
+	pt := influxdb.NewPoint("cpu", influxdb.Value(0), time.Time{})
+	if pt.HasTimeSet() {
+		t.Error("expected time to not be set")
+	}
+
+	pt = influxdb.NewPoint("cpu", influxdb.Value(0), time.Now())
+	if !pt.HasTimeSet() {
+		t.Error("expected time to be set")
+	}
+}
+
+func TestPoint_SetTime(t *testing.T) {
+	now := time.Now()
+	pt := influxdb.NewPoint("cpu", influxdb.Value(0), time.Time{})
+	if pt.Time != int64(math.MinInt64) {
+		t.Errorf("pt.Time = %q; want %q", pt.Time, int64(math.MinInt64))
+	}
+
+	pt.SetTime(now)
+	if pt.Time != now.UnixNano() {
+		t.Errorf("pt.Time = %q; want %q", pt.Time, now.UnixNano())
+	}
+
+	pt.SetTime(time.Time{})
+	if pt.Time != int64(math.MinInt64) {
+		t.Errorf("pt.Time = %q; want %q", pt.Time, int64(math.MinInt64))
+	}
+}

--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,65 @@
+package influxdb
+
+import "io"
+
+// Series represents a series included within the result.
+type Series struct {
+	Name    string
+	Tags    map[string]string
+	Columns []string
+	Values  [][]interface{}
+}
+
+// SameSeries returns if this is the same series as the other series.
+func (s *Series) SameSeries(o *Series) bool {
+	if s.Name != o.Name || len(s.Tags) != len(o.Tags) {
+		return false
+	}
+
+	for k, v1 := range s.Tags {
+		v2, ok := o.Tags[k]
+		if !ok || v1 != v2 {
+			return false
+		}
+	}
+	return true
+}
+
+// Message is a user-facing message for informational messages sent by the
+// server for a Result.
+type Message struct {
+	Level string
+	Text  string
+}
+
+// Result is a single result to be read from the query body.
+type Result struct {
+	Series   []Series
+	Messages []Message
+}
+
+// Reader reads query results from a stream.
+type Reader interface {
+	// Read reads the next Result into the Result struct passed in.
+	// This will allocate memory if the slices inside of the Result struct
+	// are not large enough to accomodate the results.
+	Read(*Result) error
+}
+
+// ReadCloser combines the Reader and io.Closer interfaces.
+type ReadCloser interface {
+	Reader
+	io.Closer
+}
+
+// NewReader constructs a new reader from the io.Reader and the QueryMeta data.
+func NewReader(r io.Reader, meta QueryMeta) (Reader, error) {
+	return nil, nil
+}
+
+// ForEach reads every result from the reader and executes the function for
+// each one. When an error is returned, the results will stop being processed
+// and the error will be returned.
+func ForEach(r Reader, fn func(*Result) error) error {
+	return nil
+}

--- a/reader.go
+++ b/reader.go
@@ -66,8 +66,12 @@ type ReadCloser interface {
 	io.Closer
 }
 
-// NewReader constructs a new reader from the io.Reader and the QueryMeta data.
-func NewReader(r io.Reader, meta QueryMeta) (Reader, error) {
+// NewReader constructs a new reader from the io.Reader and parses it with
+// the formatter.
+// The following formatters are supported:
+//   * json, application/json
+//   * csv, text/csv
+func NewReader(r io.Reader, format string) (Reader, error) {
 	return nil, nil
 }
 

--- a/reader.go
+++ b/reader.go
@@ -71,9 +71,14 @@ type ReadCloser interface {
 // The following formatters are supported:
 //   * json, application/json
 //   * csv, text/csv
-func NewReader(r io.Reader, format string) (Reader, error) {
-	return nil, nil
+func NewReader(r io.Reader, format string) (ReadCloser, error) {
+	return (*nilReader)(nil), nil
 }
+
+type nilReader struct{}
+
+func (r *nilReader) Read(*Result) error { return nil }
+func (r *nilReader) Close() error       { return nil }
 
 // ForEach reads every result from the reader and executes the function for
 // each one. When an error is returned, the results will stop being processed

--- a/reader.go
+++ b/reader.go
@@ -38,11 +38,25 @@ type Result struct {
 	Messages []Message
 }
 
+// ResultError encapsulates an error from a result.
+type ResultError struct {
+	Err string
+}
+
+// Error returns the error returned as part of the result.
+func (e *ResultError) Error() string {
+	return e.Err
+}
+
 // Reader reads query results from a stream.
 type Reader interface {
 	// Read reads the next Result into the Result struct passed in.
 	// This will allocate memory if the slices inside of the Result struct
 	// are not large enough to accomodate the results.
+	// If nil is passed to this method, the results are discarded and only
+	// an error is returned if one happened.
+	// If the next result contains an error, it will be encapsulated within a
+	// ResultError. Any other errors will be returned as-is including io.EOF.
 	Read(*Result) error
 }
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,61 @@
+package influxdb_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	influxdb "github.com/influxdata/influxdb-client"
+)
+
+func TestNewReader(t *testing.T) {
+	buffer := bytes.NewBufferString(`{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["_internal"]]}]}]}`)
+	r, err := influxdb.NewReader(buffer, "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result influxdb.Result
+	if err := r.Read(&result); err != nil {
+		t.Fatal(err)
+	}
+
+	want := influxdb.Result{
+		Series: []influxdb.Series{{
+			Name:    "databases",
+			Columns: []string{"name"},
+			Values:  [][]interface{}{{"_internal"}},
+		}},
+	}
+	if !reflect.DeepEqual(result.Series, want) {
+		t.Errorf("result.Series = %q; want %q", result.Series, want)
+	}
+	if want := []influxdb.Message(nil); !reflect.DeepEqual(result.Messages, want) {
+		t.Errorf("result.Messages = %q; want %q", result.Messages, want)
+	}
+}
+
+func TestReader_ForEach(t *testing.T) {
+	buffer := bytes.NewBufferString(`{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["_internal"]]}]}]}`)
+	r, err := influxdb.NewReader(buffer, "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	influxdb.ForEach(r, func(result *influxdb.Result) error {
+		want := influxdb.Result{
+			Series: []influxdb.Series{{
+				Name:    "databases",
+				Columns: []string{"name"},
+				Values:  [][]interface{}{{"_internal"}},
+			}},
+		}
+		if !reflect.DeepEqual(result.Series, want) {
+			t.Errorf("result.Series = %q; want %q", result.Series, want)
+		}
+		if want := []influxdb.Message(nil); !reflect.DeepEqual(result.Messages, want) {
+			t.Errorf("result.Messages = %q; want %q", result.Messages, want)
+		}
+		return nil
+	})
+}

--- a/udp_writer.go
+++ b/udp_writer.go
@@ -1,0 +1,28 @@
+package influxdb
+
+import "net"
+
+// UDPWriter writes points in line protocol to the UDP protocol. Points written
+// over UDP may be dropped when the connection is unreliable or is
+// oversaturated. Use the HTTPWriter if you need reliable transportation of
+// metrics.
+type UDPWriter struct {
+	Conn net.Conn
+}
+
+// NewUDPWriter creates a new UDPWriter.
+func NewUDPWriter(addr string) (WriteCloser, error) {
+	return nil, nil
+}
+
+// Write writes points to the UDP endpoint. Points written over UDP may be
+// dropped when the connection is unreliable or is oversaturated. Use the
+// HTTPWriter if you need reliable transportation of metrics.
+func (w *UDPWriter) Write(points ...Point) error {
+	return nil
+}
+
+// Close closes the UDP connection.
+func (w *UDPWriter) Close() error {
+	return nil
+}

--- a/udp_writer.go
+++ b/udp_writer.go
@@ -12,7 +12,7 @@ type UDPWriter struct {
 
 // NewUDPWriter creates a new UDPWriter.
 func NewUDPWriter(addr string) (WriteCloser, error) {
-	return nil, nil
+	return &UDPWriter{}, nil
 }
 
 // Write writes points to the UDP endpoint. Points written over UDP may be

--- a/udp_writer_test.go
+++ b/udp_writer_test.go
@@ -1,0 +1,69 @@
+package influxdb_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	influxdb "github.com/influxdata/influxdb-client"
+)
+
+const MAX_UDP_PAYLOAD = 64 * 1024
+
+func TestUDPWriter(t *testing.T) {
+	// Listen on a random ephemeral port.
+	saddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := net.ListenUDP("udp", saddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	addr := conn.LocalAddr()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		data := make([]byte, MAX_UDP_PAYLOAD)
+		_, _, err := conn.ReadFromUDP(data)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Create the UDP writer.
+	w, err := influxdb.NewUDPWriter(addr.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	now := time.Now()
+	pt := influxdb.NewPoint("cpu", influxdb.Value(2.0), now)
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for i := 0; i < 10; i++ {
+		if err := w.Write(pt); err != nil {
+			t.Fatal(err)
+		}
+
+		select {
+		case <-ticker.C:
+		case <-done:
+			break
+		}
+	}
+
+	// Check if the packet was received.
+	select {
+	case <-done:
+	default:
+		t.Errorf("timeout while waiting for udp packet")
+	}
+}

--- a/url.go
+++ b/url.go
@@ -1,0 +1,6 @@
+package influxdb
+
+// ParseUrl parses a url and retrieves the protocol, address, and base path (if relevant).
+func ParseUrl(rawurl string) (proto, addr, path string, err error) {
+	return "http", "localhost:8086", "", nil
+}

--- a/url_test.go
+++ b/url_test.go
@@ -1,0 +1,89 @@
+package influxdb_test
+
+import (
+	"testing"
+
+	influxdb "github.com/influxdata/influxdb-client"
+)
+
+func TestParseUrl(t *testing.T) {
+	tests := []struct {
+		url   string
+		proto string
+		addr  string
+		path  string
+	}{
+		{
+			url:   "http://localhost:8086",
+			proto: "http",
+			addr:  "localhost:8086",
+		},
+		{
+			url:   "http://localhost",
+			proto: "http",
+			addr:  "localhost",
+		},
+		{
+			url:   "http://127.0.0.1:8086",
+			proto: "http",
+			addr:  "127.0.0.1:8086",
+		},
+		{
+			url:   "http://127.0.0.1",
+			proto: "http",
+			addr:  "127.0.0.1",
+		},
+		{
+			url:   "https://localhost:8086",
+			proto: "https",
+			addr:  "localhost:8086",
+		},
+		{
+			url:   "https://localhost",
+			proto: "https",
+			addr:  "localhost",
+		},
+		{
+			url:   "https://127.0.0.1:8086",
+			proto: "https",
+			addr:  "127.0.0.1:8086",
+		},
+		{
+			url:   "https://127.0.0.1",
+			proto: "https",
+			addr:  "127.0.0.1",
+		},
+		{
+			url:   "http://localhost:8086/influxdb",
+			proto: "http",
+			addr:  "localhost:8086",
+			path:  "/influxdb",
+		},
+		{
+			url:   "unix:///var/run/influxdb.sock",
+			proto: "unix",
+			addr:  "/var/run/influxdb.sock",
+		},
+		{
+			url:  "127.0.0.1:8086",
+			addr: "127.0.0.1:8086",
+		},
+	}
+
+	for i, tt := range tests {
+		proto, addr, path, err := influxdb.ParseUrl(tt.url)
+		if err != nil {
+			t.Errorf("%d. unable to parse url: %q", i, err)
+		} else {
+			if proto != tt.proto {
+				t.Errorf("%d. proto = %q; want %q", i, proto, tt.proto)
+			}
+			if addr != tt.addr {
+				t.Errorf("%d. addr = %q; want %q", i, addr, tt.addr)
+			}
+			if path != tt.path {
+				t.Errorf("%d. path = %q; want %q", i, path, tt.path)
+			}
+		}
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,23 @@
+package influxdb
+
+import "io"
+
+// Writer is a generic interface for writing a batch of points to InfluxDB.
+type Writer interface {
+	Write(...Point) error
+}
+
+// WriteCloser combines the Writer and io.Closer interfaces.
+type WriteCloser interface {
+	Writer
+	io.Closer
+}
+
+// WriteError is an error returned by the server to indicate a permanent error
+// with the written points.
+type WriteError struct {
+}
+
+func (e WriteError) Error() string {
+	return ""
+}


### PR DESCRIPTION
# Initial API Proposal

This initial proposal needs to just be able to do two simple things. It needs to be able to query the database and write to the database.
## Queries

The basic query interface has been modified to just returning the body from the request and building additional parsing functionality on top of that. I thought about creating some kind of response struct or interface, but there were a few different use cases that I had to consider.
1. Multiple content types so there are multiple ways for a server to return data depending on what format the client asks for.
2. Some content types we will just want the client to print verbatim. JSON and CSV can be printed directly and we will continue doing that with new content types as time goes on. The column format is the only one that will not be done on the server. A client who wants to do that will choose another format and decode the format it asks for. An error will be returned if the server returns a non-200 OK status message or it will return an empty reader if 204 OK was returned instead.
3. We will have convenience methods for parsing the resulting stream.

``` go
c := &influxdb.Client{}
query, meta, err := c.RawQuery("SHOW DATABASES", &influxdb.QueryOptions{Format: "json"})
if err != nil {
    return nil
}

reader, err := influxdb.NewReader(query, meta)
// read from the query
```

This typically gets encapsulated into a `Query()` method that handles this. The user gets access to either make a `RawQuery()` or to make a `Query()` when they want to parse the results. We can change which format we request with `Query()` to the most efficient one we can (such as switching it to msgpack in the future) without any kind of negative.
## Writer

We will want to support multiple methods of writing data. The HTTP client is the most powerful and it needs to support both TCP and UNIX sockets. While UDP is there, it will only accept a hostname and does not need to use a `influxdb.Client` struct since it has no connection to that piece of code. All batch writing interfaces are unified with an `influxdb.Writer` interface along with just having a convenience method on the client itself. The `influxdb.Writer` assumes it will only be writing to one database or retention policy. If they need to write to multiple databases or retention policies, they will need to make multiple writers.
