### PR TITLE
Refactor the writer interface and create buffered writers

### DIFF
--- a/buffered_writer.go
+++ b/buffered_writer.go
@@ -1,0 +1,63 @@
+package influxdb
+
+import (
+	"bufio"
+	"io"
+)
+
+const (
+	defaultBufSize = 4096
+)
+
+var _ Writer = &BufferedWriter{}
+
+// BufferedWriter is a custom bufio.BufferedWriter that will never split the
+// contents of a Write call between calls to Write. If a Write would cause the
+// buffer to be exceeded, it will first flush the contents and then initiate
+// the write. This is to avoid splitting line protocol between two separate
+// writes.
+type BufferedWriter struct {
+	bw *bufio.Writer
+	p  Protocol
+}
+
+// NewBufferedWriter creates a new BufferedWriter. If the io.Writer passed in
+// is a Writer, the BufferedWriter copies the Precision from that.
+func NewBufferedWriter(w io.Writer) *BufferedWriter {
+	return NewBufferedWriterSize(w, defaultBufSize)
+}
+
+// NewBufferedWriterSize creates a new BufferedWriter with a size of size.
+func NewBufferedWriterSize(w io.Writer, size int) *BufferedWriter {
+	protocol := DefaultWriteProtocol
+	if w, ok := w.(Writer); ok {
+		protocol = w.Protocol()
+	}
+
+	return &BufferedWriter{
+		bw: bufio.NewWriterSize(w, size),
+		p:  protocol,
+	}
+}
+
+// Protocol returns the Protocol associated with this BufferedWriter.
+func (w *BufferedWriter) Protocol() Protocol {
+	return w.p
+}
+
+func (w *BufferedWriter) Write(p []byte) (n int, err error) {
+	if len(p) > w.bw.Available() {
+		// Flush the data in the buffer before writing.
+		if w.bw.Buffered() != 0 {
+			if err = w.bw.Flush(); err != nil {
+				return n, err
+			}
+		}
+	}
+	return w.bw.Write(p)
+}
+
+// Flush causes any bytes buffered to be written to the underlying Writer.
+func (w *BufferedWriter) Flush() error {
+	return w.bw.Flush()
+}

--- a/buffered_writer_test.go
+++ b/buffered_writer_test.go
@@ -1,0 +1,92 @@
+package influxdb_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	influxdb "github.com/influxdata/influxdb-client"
+)
+
+func TestBufferedWriter(t *testing.T) {
+	calls := 0
+	protocol := influxdb.DefaultWriteProtocol
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, "POST"; got != want {
+			t.Errorf("Method = %q; want %q", got, want)
+		}
+
+		values := r.URL.Query()
+		if got, want := values.Get("db"), "db0"; got != want {
+			t.Errorf("db = %q; want %q", got, want)
+		}
+		if got, want := values.Get("rp"), "rp0"; got != want {
+			t.Errorf("rp = %q; want %q", got, want)
+		}
+		if got, want := r.Header.Get("Content-Type"), protocol.ContentType(); got != want {
+			t.Errorf("Content-Type = %q; want %q", got, want)
+		}
+
+		data, _ := ioutil.ReadAll(r.Body)
+		if got, want := string(data), "cpu,host=server01 value=5\n"; got != want {
+			t.Errorf("body = %q; want %q", got, want)
+		}
+		calls++
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := influxdb.NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writer := client.Writer()
+	writer.Database = "db0"
+	writer.RetentionPolicy = "rp0"
+	bw := influxdb.NewBufferedWriterSize(writer, 32)
+
+	pt := influxdb.Point{
+		Name:   "cpu",
+		Tags:   influxdb.Tags{{Key: "host", Value: "server01"}},
+		Fields: map[string]interface{}{"value": 5.0},
+	}
+	if _, err := pt.WriteTo(bw); err != nil {
+		t.Fatal(err)
+	} else if have, want := calls, 0; have != want {
+		t.Fatalf("invalid number of write calls: have=%#v want=%#v", have, want)
+	}
+	if _, err := pt.WriteTo(bw); err != nil {
+		t.Fatal(err)
+	} else if have, want := calls, 1; have != want {
+		t.Fatalf("invalid number of write calls: have=%#v want=%#v", have, want)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatal(err)
+	} else if have, want := calls, 2; have != want {
+		t.Fatalf("invalid number of write calls: have=%#v want=%#v", have, want)
+	}
+}
+
+func TestWritePoints_BufferedWriter(t *testing.T) {
+	// Create the initial buffered writer.
+	var buf bytes.Buffer
+	w := influxdb.NewBufferedWriter(&buf)
+
+	pt := influxdb.Point{
+		Name:   "cpu",
+		Tags:   influxdb.Tags{{Key: "host", Value: "server01"}},
+		Fields: map[string]interface{}{"value": 5.0},
+	}
+	if _, err := influxdb.WritePoints(w, []influxdb.Point{pt}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// There should be nothing written to the internal buffer.
+	if have, want := buf.Len(), 26; have != want {
+		t.Fatalf("unexpected buffer length: have=%#v want=%#v", have, want)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -240,8 +240,14 @@ func (c *Client) Execute(q interface{}, opts ...QueryOption) error {
 	return querier.Execute(q, opts...)
 }
 
-func (c *Client) Writer() *Writer {
-	return &Writer{c: c}
+// Writer creates a Writer that will use this Client to write to the database.
+func (c *Client) Writer() *HTTPWriter {
+	return &HTTPWriter{
+		c: c,
+		WriteOptions: WriteOptions{
+			Protocol: DefaultWriteProtocol,
+		},
+	}
 }
 
 // url constructs a URL object for this client.

--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,7 @@ var (
 	ErrSeriesTruncated = errors.New("truncated output")
 )
 
+// ErrPing wraps the error returned when attempting to ping the server and it fails.
 type ErrPing struct {
 	Cause error
 }
@@ -28,6 +29,7 @@ func (e ErrPing) Error() string {
 	return fmt.Sprintf("ping failed: %s", e.Cause)
 }
 
+// ErrUnknownFormat is returned whenever an unknown cursor format is used.
 type ErrUnknownFormat struct {
 	Format string
 }
@@ -36,6 +38,7 @@ func (e ErrUnknownFormat) Error() string {
 	return fmt.Sprintf("unknown format: %s", e.Format)
 }
 
+// ErrResult wraps an error returned for a statement in a query.
 type ErrResult struct {
 	Err string
 }
@@ -44,6 +47,7 @@ func (e ErrResult) Error() string {
 	return e.Err
 }
 
+// ErrPartialWrite is returned whenever a partial write is detected.
 type ErrPartialWrite struct {
 	Err string
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,43 @@
+package influxdb_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	influxdb "github.com/influxdata/influxdb-client"
+)
+
+func TestReadError_JSONError(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: ioutil.NopCloser(strings.NewReader(`{"error":"expected err"}`)),
+	}
+
+	if err := influxdb.ReadError(resp); err == nil {
+		t.Error("expected error")
+	} else if have, want := err.Error(), "expected err"; have != want {
+		t.Errorf("unexpected error: have=%#v want=%#v", have, want)
+	}
+}
+
+func TestReadError_UnknownError(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body:       ioutil.NopCloser(strings.NewReader(``)),
+		Status:     fmt.Sprintf("%d %s", http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)),
+		StatusCode: http.StatusInternalServerError,
+	}
+
+	if err := influxdb.ReadError(resp); err == nil {
+		t.Error("expected error")
+	} else if have, want := err.Error(), "unknown http error: 500 Internal Server Error"; have != want {
+		t.Errorf("unexpected error: have=%#v want=%#v", have, want)
+	}
+}

--- a/pkg.go
+++ b/pkg.go
@@ -9,7 +9,7 @@ func Ping() (ServerInfo, error) {
 	return DefaultClient.Ping()
 }
 
-// Querier returns a struct that can be used to save query options and execute queries.
+// DefaultQuerier returns a struct that can be used to save query options and execute queries.
 func DefaultQuerier() *Querier {
 	return DefaultClient.Querier()
 }

--- a/point.go
+++ b/point.go
@@ -2,6 +2,7 @@ package influxdb
 
 import (
 	"bytes"
+	"io"
 	"time"
 )
 
@@ -38,4 +39,15 @@ type Point struct {
 	Tags   Tags
 	Fields map[string]interface{}
 	Time   time.Time
+}
+
+// WriteTo writes this Point to the io.Writer using the default write protocol.
+// If the target io.Writer is an Writer, this uses the Protocol associated with
+// that Writer.
+func (pt *Point) WriteTo(w io.Writer) (n int, err error) {
+	p := DefaultWriteProtocol
+	if w, ok := w.(Writer); ok {
+		p = w.Protocol()
+	}
+	return p.Encode(w, pt)
 }

--- a/point_test.go
+++ b/point_test.go
@@ -27,3 +27,14 @@ func TestTags_Sort(t *testing.T) {
 		t.Errorf("have %q, want %q", tags[0].Value, "useast")
 	}
 }
+
+func TestTags_String(t *testing.T) {
+	tags := influxdb.Tags([]influxdb.Tag{
+		{Key: "host", Value: "server01"},
+		{Key: "region", Value: "useast"},
+	})
+
+	if have, want := tags.String(), "host=server01,region=useast"; have != want {
+		t.Errorf("unexpected tags string: have=%#v want=%#v", have, want)
+	}
+}

--- a/precision.go
+++ b/precision.go
@@ -1,5 +1,7 @@
 package influxdb
 
+import "fmt"
+
 // Precision is the requested precision.
 type Precision string
 
@@ -25,4 +27,35 @@ const (
 
 func (p Precision) String() string {
 	return string(p)
+}
+
+// WithPrecision augments the protocol with the given precision. If the
+// protocol cannot be augmented natively, this wraps it in a protocol that will
+// truncate the time for any encoded points to the given precision.
+func WithPrecision(protocol Protocol, precision Precision) Protocol {
+	// Switch on known protocols to avoid reflection.
+	switch protocol := protocol.(type) {
+	case *lineProtocolV1:
+		newP := &lineProtocolV1{}
+		if protocol != nil {
+			*newP = *protocol
+		}
+		newP.Precision = precision
+		return newP
+	default:
+		// TODO(jsternberg): Implement the augmented protocol.
+		panic(fmt.Sprintf("unsupported protocol type: %T", protocol))
+	}
+}
+
+// GetPrecision retrieves the precision from a protocol. If the precision could
+// not be discovered, this returns an empty string.
+func GetPrecision(protocol Protocol) Precision {
+	switch protocol := protocol.(type) {
+	case *lineProtocolV1:
+		if protocol != nil {
+			return protocol.Precision
+		}
+	}
+	return PrecisionNanosecond
 }

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -2,13 +2,34 @@ package influxdb_test
 
 import (
 	"bytes"
+	"io/ioutil"
 	"testing"
 	"time"
 
 	influxdb "github.com/influxdata/influxdb-client"
 )
 
-func TestLineProtocol_V1(t *testing.T) {
+func TestEncode(t *testing.T) {
+	var buf bytes.Buffer
+	pt := influxdb.Point{
+		Name: "cpu",
+		Tags: []influxdb.Tag{
+			{Key: "host", Value: "server01"},
+		},
+		Fields: map[string]interface{}{
+			"value": float64(5),
+		},
+		Time: time.Unix(2, 0),
+	}
+
+	if _, err := influxdb.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu,host=server01 value=5 2000000000\n"; have != want {
+		t.Fatalf("unexpected protocol output: have=%#v want=%#v", have, want)
+	}
+}
+
+func TestLineProtocol_V1_Encode(t *testing.T) {
 	var buf bytes.Buffer
 	p := influxdb.LineProtocol.V1()
 
@@ -19,7 +40,7 @@ func TestLineProtocol_V1(t *testing.T) {
 		},
 	}
 
-	if err := p.Encode(&buf, &pt, influxdb.EncodeOptions{}); err != nil {
+	if _, err := p.Encode(&buf, &pt); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -30,7 +51,7 @@ func TestLineProtocol_V1(t *testing.T) {
 	buf.Reset()
 	pt.Tags = []influxdb.Tag{{Key: "host", Value: "server01"}}
 
-	if err := p.Encode(&buf, &pt, influxdb.EncodeOptions{}); err != nil {
+	if _, err := p.Encode(&buf, &pt); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -41,11 +62,185 @@ func TestLineProtocol_V1(t *testing.T) {
 	buf.Reset()
 	pt.Time = time.Unix(0, 1000)
 
-	if err := p.Encode(&buf, &pt, influxdb.EncodeOptions{}); err != nil {
+	if _, err := p.Encode(&buf, &pt); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	if got, want := buf.String(), "cpu,host=server01 value=5 1000\n"; got != want {
 		t.Errorf("unexpected protocol output:\n\ngot=%v\nwant=%v\n", got, want)
+	}
+}
+
+func TestLineProtocol_V1_ErrNoFields(t *testing.T) {
+	var buf bytes.Buffer
+	p := influxdb.LineProtocol.V1()
+
+	pt := influxdb.Point{Name: "cpu"}
+	if _, err := p.Encode(&buf, &pt); err != influxdb.ErrNoFields {
+		t.Fatal("unexpected error: %v", err)
+	}
+}
+
+func TestLineProtocol_V1_WithPrecision(t *testing.T) {
+	var buf bytes.Buffer
+	p := influxdb.LineProtocol.V1()
+
+	pt := influxdb.Point{
+		Name: "cpu",
+		Tags: []influxdb.Tag{
+			{Key: "host", Value: "server01"},
+		},
+		Fields: map[string]interface{}{
+			"value": float64(5),
+		},
+		Time: time.Unix(7265, 769142873),
+	}
+
+	p = influxdb.WithPrecision(p, influxdb.PrecisionNanosecond)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu,host=server01 value=5 7265769142873\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	p = influxdb.WithPrecision(p, influxdb.PrecisionMicrosecond)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu,host=server01 value=5 7265769142\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	p = influxdb.WithPrecision(p, influxdb.PrecisionMillisecond)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu,host=server01 value=5 7265769\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	p = influxdb.WithPrecision(p, influxdb.PrecisionSecond)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu,host=server01 value=5 7265\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	p = influxdb.WithPrecision(p, influxdb.PrecisionMinute)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu,host=server01 value=5 121\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	p = influxdb.WithPrecision(p, influxdb.PrecisionHour)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu,host=server01 value=5 2\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+}
+
+func TestLineProtocol_V1_Fields(t *testing.T) {
+	var buf bytes.Buffer
+	p := influxdb.LineProtocol.V1()
+
+	pt := influxdb.Point{
+		Name:   "cpu",
+		Fields: map[string]interface{}{},
+	}
+
+	pt.Fields["value"] = float64(5)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu value=5\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	pt.Fields["value"] = float32(5)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu value=5\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	pt.Fields["value"] = int64(5)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu value=5i\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	pt.Fields["value"] = int32(5)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu value=5i\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	pt.Fields["value"] = int(5)
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu value=5i\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	pt.Fields["value"] = "foobar"
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu value=\"foobar\"\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	pt.Fields["value"] = true
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu value=t\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	pt.Fields["value"] = false
+	if _, err := p.Encode(&buf, &pt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if have, want := buf.String(), "cpu value=f\n"; have != want {
+		t.Errorf("unexpected output: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+
+	pt.Fields["value"] = struct{}{}
+	if _, err := p.Encode(&buf, &pt); err == nil {
+		t.Error("expected error")
+	} else if have, want := err.Error(), "invalid field type: struct {}"; have != want {
+		t.Errorf("unexpected error: have=%#v want=%#v", have, want)
+	}
+	buf.Reset()
+}
+
+func BenchmarkLineProtocol_V1(b *testing.B) {
+	pt := influxdb.Point{
+		Name: "cpu",
+		Tags: []influxdb.Tag{
+			{Key: "host", Value: "server01"},
+		},
+		Fields: map[string]interface{}{
+			"value": float64(5),
+		},
+		Time: time.Unix(25, 0),
+	}
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		pt.WriteTo(ioutil.Discard)
 	}
 }

--- a/timed_writer.go
+++ b/timed_writer.go
@@ -1,0 +1,47 @@
+package influxdb
+
+import "time"
+
+var _ Writer = &TimedWriter{}
+
+// TimedWriter wraps a BufferedWriter and automatically flushes it after each
+// duration passes.
+type TimedWriter struct {
+	*BufferedWriter
+	ticker *time.Ticker
+	done   chan struct{}
+}
+
+// NewTimedWriter creates a new TimedWriter from a BufferedWriter and will
+// flush every d time.Duration. After the TimedWriter is created, it must be
+// stopped using Stop or this will leak a goroutine that will run infinitely.
+func NewTimedWriter(bw *BufferedWriter, d time.Duration) *TimedWriter {
+	w := &TimedWriter{
+		BufferedWriter: bw,
+		ticker:         time.NewTicker(d),
+		done:           make(chan struct{}),
+	}
+	go w.loop()
+	return w
+}
+
+// Stop stops this TimedWriter. This method will panic if called multiple
+// times.
+func (w *TimedWriter) Stop() {
+	w.ticker.Stop()
+	close(w.done)
+}
+
+// loop will automatically flush the BufferedWriter each interval or until the
+// TimedWriter is stopped.
+func (w *TimedWriter) loop() {
+	for {
+		select {
+		case <-w.ticker.C:
+			// TODO(jsternberg): Add some way to perform logging.
+			w.Flush()
+		case <-w.done:
+			return
+		}
+	}
+}

--- a/timed_writer_test.go
+++ b/timed_writer_test.go
@@ -1,0 +1,39 @@
+package influxdb_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	influxdb "github.com/influxdata/influxdb-client"
+)
+
+func TestTimedWriter(t *testing.T) {
+	// Create the initial buffered writer.
+	var buf bytes.Buffer
+	bw := influxdb.NewBufferedWriter(&buf)
+
+	pt := influxdb.Point{
+		Name:   "cpu",
+		Tags:   influxdb.Tags{{Key: "host", Value: "server01"}},
+		Fields: map[string]interface{}{"value": 5.0},
+	}
+	if _, err := pt.WriteTo(bw); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// There should be nothing written to the internal buffer.
+	if have, want := buf.Len(), 0; have != want {
+		t.Fatalf("unexpected buffer length: have=%#v want=%#v", have, want)
+	}
+
+	// Wrap in a timed writer and wait until the interval passes.
+	w := influxdb.NewTimedWriter(bw, 10*time.Millisecond)
+	defer w.Stop()
+	<-time.After(20 * time.Millisecond)
+
+	// Data should have been written.
+	if have, want := buf.Len(), 26; have != want {
+		t.Fatalf("unexpected buffer length: have=%#v want=%#v", have, want)
+	}
+}

--- a/udp_writer.go
+++ b/udp_writer.go
@@ -1,0 +1,43 @@
+package influxdb
+
+import "net"
+
+// MaxUDPPayloadSize is a reasonable maximum payload size for UDP packets that
+// could be traveling over the internet.
+const MaxUDPPayloadSize = 512
+
+var _ Writer = &UDPWriter{}
+
+// UDPWriter is a simple writer that will write points over udp.
+type UDPWriter struct {
+	conn net.Conn
+}
+
+// NewUDPWriter creates a new UDPWriter that will be sent to the specified
+// address and will be encoded with the given protocol.
+func NewUDPWriter(addr string) (*UDPWriter, error) {
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return &UDPWriter{conn: conn}, nil
+}
+
+// Write will write the data directly to the UDP socket.
+func (w *UDPWriter) Write(data []byte) (n int, err error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	return w.conn.Write(data)
+}
+
+// Protocol returns the protocol associated with this UDP writer.
+// This will always be the DefaultWriteProtocol.
+func (w *UDPWriter) Protocol() Protocol {
+	return DefaultWriteProtocol
+}
+
+// Close closes the UDP socket.
+func (w *UDPWriter) Close() error {
+	return w.conn.Close()
+}

--- a/udp_writer_test.go
+++ b/udp_writer_test.go
@@ -1,0 +1,163 @@
+package influxdb_test
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	influxdb "github.com/influxdata/influxdb-client"
+)
+
+func TestUDPWriter_WritePoint(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	type resp struct {
+		out string
+		err error
+	}
+	in := make(chan resp, 5)
+	go func() {
+		buf := make([]byte, 1024)
+		n, _, err := conn.ReadFromUDP(buf)
+
+		var out []byte
+		if err == nil {
+			out = make([]byte, n)
+			copy(out, buf[:n])
+		}
+		in <- resp{out: string(out), err: err}
+		close(in)
+	}()
+
+	w, err := influxdb.NewUDPWriter(conn.LocalAddr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	pt := influxdb.Point{
+		Name:   "cpu",
+		Fields: map[string]interface{}{"value": 5.0},
+		Time:   time.Unix(10, 0),
+	}
+	if _, err := pt.WriteTo(w); err != nil {
+		t.Fatalf("unable to write udp message: %s", err)
+	}
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	select {
+	case <-timer.C:
+		t.Fatal("no udp message received")
+	case r := <-in:
+		timer.Stop()
+
+		if r.err != nil {
+			t.Fatalf("error reading from udp socket: %s", r.err)
+		} else if got, want := r.out, "cpu value=5 10000000000\n"; got != want {
+			t.Fatalf("unexpected udp message: got=%q want=%q", got, want)
+		}
+	}
+
+	timer = time.NewTimer(100 * time.Millisecond)
+	select {
+	case <-timer.C:
+		t.Fatal("unexpected timeout while waiting for udp reader to close")
+	case <-in:
+		timer.Stop()
+	}
+}
+
+func TestUDPWriter_MultiplePayloads(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Retrieve the length of writing one point.
+	pt := influxdb.Point{
+		Name:   "cpu",
+		Tags:   []influxdb.Tag{{Key: "host", Value: "server01"}},
+		Fields: map[string]interface{}{"value": 5.0},
+		Time:   time.Unix(10, 0),
+	}
+	var buf bytes.Buffer
+	if _, err := influxdb.Encode(&buf, &pt); err != nil {
+		t.Fatal(err)
+	}
+	len := buf.Len()
+
+	points := make([]influxdb.Point, (influxdb.MaxUDPPayloadSize/len)+1)
+	for i := range points {
+		points[i] = pt
+	}
+
+	type resp struct {
+		out string
+		err error
+	}
+	in := make(chan resp, 5)
+	go func() {
+		for i := 0; i < 2; i++ {
+			buf := make([]byte, 64*1024)
+			n, _, err := conn.ReadFromUDP(buf)
+
+			var out []byte
+			if err == nil {
+				out = make([]byte, n)
+				copy(out, buf[:n])
+			}
+			in <- resp{out: string(out), err: err}
+		}
+		close(in)
+	}()
+
+	w, err := influxdb.NewUDPWriter(conn.LocalAddr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	if _, err := influxdb.WritePoints(w, points); err != nil {
+		t.Fatalf("unable to write udp message: %s", err)
+	}
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	select {
+	case <-timer.C:
+		t.Fatal("no udp message received")
+	case r := <-in:
+		timer.Stop()
+
+		if r.err != nil {
+			t.Fatalf("error reading from udp socket: %s", r.err)
+		}
+	}
+
+	timer = time.NewTimer(100 * time.Millisecond)
+	select {
+	case <-timer.C:
+		t.Fatal("no udp message received")
+	case r := <-in:
+		timer.Stop()
+
+		if r.err != nil {
+			t.Fatalf("error reading from udp socket: %s", r.err)
+		} else if got, want := r.out, "cpu,host=server01 value=5 10000000000\n"; got != want {
+			t.Fatalf("unexpected udp message: got=%q want=%q", got, want)
+		}
+	}
+
+	timer = time.NewTimer(100 * time.Millisecond)
+	select {
+	case <-timer.C:
+		t.Fatal("unexpected timeout while waiting for udp reader to close")
+	case <-in:
+		timer.Stop()
+	}
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,18 +1,16 @@
 package influxdb_test
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
 	influxdb "github.com/influxdata/influxdb-client"
 )
 
-func TestWriter_WritePoint(t *testing.T) {
+func TestHttpWriter_WritePoint(t *testing.T) {
 	protocol := influxdb.DefaultWriteProtocol
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.Method, "POST"; got != want {
@@ -53,55 +51,12 @@ func TestWriter_WritePoint(t *testing.T) {
 		Tags:   influxdb.Tags{{Key: "host", Value: "server01"}},
 		Fields: map[string]interface{}{"value": 5.0},
 	}
-	if _, err := writer.WritePoint(pt); err != nil {
+	if _, err := pt.WriteTo(writer); err != nil {
 		t.Fatal(err)
 	}
 }
 
-// This tests if io.Copy works with the Writer.
-func TestWriter_Copy(t *testing.T) {
-	protocol := influxdb.DefaultWriteProtocol
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.Method, "POST"; got != want {
-			t.Errorf("Method = %q; want %q", got, want)
-		}
-
-		values := r.URL.Query()
-		if got, want := values.Get("db"), "db0"; got != want {
-			t.Errorf("db = %q; want %q", got, want)
-		}
-		if got, want := values.Get("rp"), "rp0"; got != want {
-			t.Errorf("rp = %q; want %q", got, want)
-		}
-		if got, want := r.Header.Get("Content-Type"), protocol.ContentType(); got != want {
-			t.Errorf("Content-Type = %q; want %q", got, want)
-		}
-
-		data, _ := ioutil.ReadAll(r.Body)
-		if got, want := string(data), "cpu,host=server01 value=5\n"; got != want {
-			t.Errorf("body = %q; want %q", got, want)
-		}
-
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer server.Close()
-
-	client, err := influxdb.NewClient(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	writer := client.Writer()
-	writer.Database = "db0"
-	writer.RetentionPolicy = "rp0"
-
-	r := strings.NewReader("cpu,host=server01 value=5\n")
-	if _, err := io.Copy(writer, r); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestWriter_ConsistencyAndPrecision(t *testing.T) {
+func TestHttpWriter_ConsistencyAndPrecision(t *testing.T) {
 	protocol := influxdb.DefaultWriteProtocol
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.Method, "POST"; got != want {
@@ -143,7 +98,7 @@ func TestWriter_ConsistencyAndPrecision(t *testing.T) {
 	writer.Database = "db0"
 	writer.RetentionPolicy = "rp0"
 	writer.Consistency = influxdb.ConsistencyAny
-	writer.Precision = influxdb.PrecisionSecond
+	writer.WriteOptions.Protocol = influxdb.WithPrecision(writer.Protocol(), influxdb.PrecisionSecond)
 
 	pt := influxdb.Point{
 		Name:   "cpu",
@@ -151,7 +106,7 @@ func TestWriter_ConsistencyAndPrecision(t *testing.T) {
 		Fields: map[string]interface{}{"value": 5.0},
 		Time:   time.Unix(10, 0),
 	}
-	if _, err := writer.WritePoint(pt); err != nil {
+	if _, err := pt.WriteTo(writer); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Make Writer into an interface that exposes `io.Writer` and the protocol
that should be written to the underlying writer.

Include the precision within the protocol itself too.

Read global error messages from the result.

Include a BufferedWriter that ensures that different lines of the
protocol do not get split. WritePoints will now call Write once for
every line of the line protocol and the BufferedWriter should be used to
control when it writes. WritePoints will automatically call Flush on the
Writer that's passed in if it has that function, otherwise it will
assume everything was written directly to the underlying io.Writer.

Also includes a TimedWriter. The TimedWriter wraps the BufferedWriter
and will automatically flush the BufferedWriter at a duration. The
TimedWriter must be stopped after it is created to avoid leaking a
goroutine.

Modifies WritePoints to flush the buffer of the passed in Writer
automatically if it exists. This feature is exclusive to WritePoints and
does not affect `(*Point).WriteTo`.

Adds a buffer pool for writing points to the v1 line protocol. This way,
you cannot accidentally call `Encode()` and get a half-written point to
the `io.Writer`.